### PR TITLE
Fix having multiple Elements with PackageReference

### DIFF
--- a/src-ext/project-file-loader.ts
+++ b/src-ext/project-file-loader.ts
@@ -23,13 +23,8 @@ export default class ProjectFileLoader {
     if (!parsedXml.Project.ItemGroup) {
       return [];
     }
-    const packageReferenceGroup = parsedXml.Project.ItemGroup.find((itemGroup: any) => itemGroup.PackageReference !== undefined);
 
-    if (!packageReferenceGroup) {
-      return [];
-    }
-
-    const packageReferences = packageReferenceGroup.PackageReference as Array<any>;
+    const packageReferences = parsedXml.Project.ItemGroup.filter((itemGroup: any) => itemGroup.PackageReference !== undefined).flatMap((itemGroup: { PackageReference: Array<any> }) => itemGroup.PackageReference);
 
     const packages = packageReferences.map((packageReference: any) => {
       return {


### PR DESCRIPTION
When there are multiple ItemGroup Elements that have PackageReference, Now all PackageReferences are used.

In the following exalple only `CSVParserGenerator` and `AutoInvoke.Generator` would be displayed.

```xml
  <ItemGroup>
    <PackageReference Include="CSVParserGenerator" Version="1.6.0" />
    <PackageReference Include="AutoInvoke.Generator" Version="0.0.3" />
  </ItemGroup>
  <ItemGroup>
    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
    <PackageReference Include="System.ServiceModel.Duplex" Version="4.10.*" />
    <PackageReference Include="System.ServiceModel.Http" Version="4.10.*" />
    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.10.*" />
    <PackageReference Include="System.ServiceModel.Security" Version="4.10.*" />
    <PackageReference Include="System.ServiceModel.Federation" Version="4.10.*" />
    <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.4.0" />
    <PackageReference Include="Karambolo.Extensions.Logging.File.Json" Version="3.4.0" />
  </ItemGroup>
```

I at least hopa that this will fix it, I had problems to manual test it…